### PR TITLE
Add BenchmarkSkiplistSizeLevel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,10 @@ module github.com/couchbasedeps/fast-skiplist
 
 go 1.24.3
 
-require github.com/stretchr/testify v1.10.0 // indirect
+require github.com/stretchr/testify v1.10.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)


### PR DESCRIPTION
- Go mod fix
- Add benchmark to evaluate levels parameter for varying numbers of list sizes

![Screenshot 2025-06-26 at 15 25 26](https://github.com/user-attachments/assets/bfe66e69-a94b-4937-9f28-3ac32a0512f5)
